### PR TITLE
Fix screen 'search'

### DIFF
--- a/src/main/java/killrvideo/entity/Video.java
+++ b/src/main/java/killrvideo/entity/Video.java
@@ -13,6 +13,7 @@ import com.datastax.driver.mapping.annotations.PartitionKey;
 import com.datastax.driver.mapping.annotations.Table;
 
 import killrvideo.search.SearchServiceOuterClass.SearchResultsVideoPreview;
+import killrvideo.search.SearchServiceOuterClass.SearchResultsVideoPreview.Builder;
 import killrvideo.suggested_videos.SuggestedVideosService.SuggestedVideoPreview;
 import killrvideo.utils.EmptyCollectionIfNull;
 import killrvideo.utils.TypeConverter;
@@ -119,14 +120,13 @@ public class Video extends AbstractVideo {
      * Mapping to generated GPRC beans (Search result special).
      */
     public SearchResultsVideoPreview toResultVideoPreview() {
-        return SearchResultsVideoPreview
-                .newBuilder()
-                .setAddedDate(TypeConverter.dateToTimestamp(addedDate))
-                .setName(name)
-                .setPreviewImageLocation(previewImageLocation)
-                .setUserId(TypeConverter.uuidToUuid(userid))
-                .setVideoId(TypeConverter.uuidToUuid(videoid))
-                .build();
+    	Builder builder = SearchResultsVideoPreview.newBuilder();
+    	builder.setName(name);
+    	if (previewImageLocation != null)  builder.setPreviewImageLocation(previewImageLocation);
+    	if (userid != null)    			   builder.setUserId(TypeConverter.uuidToUuid(userid));
+    	if (videoid != null)   			   builder.setVideoId(TypeConverter.uuidToUuid(videoid));
+    	if (addedDate != null) 			   builder.setAddedDate(TypeConverter.dateToTimestamp(addedDate));
+        return builder.build();
     }
 
     /**

--- a/src/main/java/killrvideo/service/SearchService.java
+++ b/src/main/java/killrvideo/service/SearchService.java
@@ -80,20 +80,14 @@ public class SearchService extends SearchServiceImplBase {
                         .where(QueryBuilder.eq("solr_query", QueryBuilder.bindMarker()))
         ).setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
 
-        searchVideos_getVideosWithSearchPrepared = getQuerySuggestions_getTagsPrepared;
-        
-        /*
-         *  Warning at startup because initialized twice the same query
-         *  
-               dseSession.prepare(
+        searchVideos_getVideosWithSearchPrepared = dseSession.prepare(
                 QueryBuilder
-                        .select()
-                        .all()
-                        .from(Schema.KEYSPACE, videosTableName)
-                        .where(QueryBuilder.eq("solr_query", QueryBuilder.bindMarker()))
+                .select()
+                .all()
+                .from(Schema.KEYSPACE, videosTableName)
+                .where(QueryBuilder.eq("solr_query", QueryBuilder.bindMarker()))
         ).setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
-        */
-
+        
         /**
          * Create a set of sentence conjunctions and other "undesirable"
          * words we will use later to exclude from search results
@@ -161,8 +155,8 @@ public class SearchService extends SearchServiceImplBase {
                 .append(requestQuery).append("\", \"paging\":\"driver\"}");
 
         LOGGER.debug("searchVideos() solr_query is : " + solrQuery);
-        BoundStatement statement = searchVideos_getVideosWithSearchPrepared.bind()
-                .setString("solr_query", solrQuery.toString());
+        BoundStatement statement = searchVideos_getVideosWithSearchPrepared.bind().setString("solr_query", solrQuery.toString());
+        LOGGER.debug("Executed query is : " + statement.preparedStatement().getQueryString());
 
         statement.setFetchSize(request.getPageSize());
 


### PR DESCRIPTION
On SearchService, the `searchVideos` method used the same `PrepareStatement` as `getQuerySuggestions`. The first need all fields to display preview where the second only 2 columns. We got a mapping error when trying to map field as null. (required field in GRPC Bean). 

```java
 searchVideos_getVideosWithSearchPrepared = dseSession.prepare(
                QueryBuilder
                .select()
                .all() //fix
                .from(Schema.KEYSPACE, videosTableName)
                .where(QueryBuilder.eq("solr_query", QueryBuilder.bindMarker()))
        ).setConsistencyLevel(ConsistencyLevel.LOCAL_ONE);
```
- Mapping has been strengthen
- Correct statement with select().all() has been reintroduced